### PR TITLE
Ensure scatter brush compliance and reverse engineer behavior

### DIFF
--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -1,0 +1,116 @@
+# Scatter Brush Compliance Checklist (RTX Remix Toolkit)
+
+This document is the authoritative compliance checklist for the RTX Remix Toolkit Scatter Brush. It maps requirements to official NVIDIA/OpenUSD guidance and flags any gaps requiring further confirmation.
+
+## Scope
+- Authoring and editing of Scatter Brush data using OpenUSD `UsdGeomPointInstancer` in RTX Remix Toolkit (Trex)
+- UI and interaction semantics equivalent to USD Composer/Omniverse Scatter/Paint tools
+- Packaging/export considerations for Remix Runtime (DXVK-Remix/RTX-Remix)
+
+## Authoritative References
+- OpenUSD
+  - UsdGeomPointInstancer Class Reference — openusd: `https://openusd.org/docs/api/class_usd_geom_point_instancer.html`
+  - Instancing overview (prototypes, instanceability) — openusd: `https://openusd.org/docs/UsdGeom-Instancing.html`
+- NVIDIA Omniverse
+  - Build a Scatter Tool (Workflows) — Omniverse: `https://docs.omniverse.nvidia.com/workflows/latest/extensions/scatter_tool.html`
+  - Paint Tool (Scatter brush behaviors) — Omniverse: `https://docs.omniverse.nvidia.com/extensions/latest/ext_paint-tool.html`
+  - Omnigraph Scatter nodes (optional pipeline) — Omniverse: `https://docs.omniverse.nvidia.com/extensions/latest/ext_omnigraph/node-library/nodes/omni-flora-core/scatter-1.html`
+- RTX Remix Toolkit (local docs in repo)
+  - Viewport options — Merge Instances / Use Fabric Scene Graph Instancing: see `docs/toolkitinterface/remix-toolkitinterface-viewport.md`
+  - REST API tutorial (patterns for authoring ops) — `docs/tutorials/tutorial-restapi.md`
+- GitHub Repositories
+  - @ToolkitGithubDocs — Toolkit (this repo): `https://github.com/NVIDIAGameWorks/toolkit-remix`
+  - @RTX-RemixGithub — Runtime: `https://github.com/NVIDIAGameWorks/rtx-remix`
+  - @DXVK-RemixGithub — DXVK Remix: `https://github.com/NVIDIAGameWorks/dxvk-remix`
+  - @Bridge-RemixGithub — Remix Bridge: (TBD — fetch exact repo URL)
+  - @ComfyUI-RTX-RemixGithub — (TBD — fetch exact repo URL)
+  - @USDToolset — OpenUSD docs (see links above) and Omniverse USD references
+  - @RestAPIScreen — local `docs/tutorials/tutorial-restapi.md`
+
+## USD Schema Compliance (PointInstancer)
+- [ ] Use `UsdGeomPointInstancer` for scattered instances
+  - [ ] Author `prototypes` relationship targeting root prims (OpenUSD PI: Prototypes)
+  - [ ] Author `protoIndices` array (int) mapping each instance to a prototype index
+  - [ ] Author `positions` (GfVec3f/d) per instance
+  - [ ] Optional `orientations` (GfQuath) per instance; default identity if omitted
+  - [ ] Optional `scales` (GfVec3f) per instance; default ones if omitted
+  - [ ] Optional `ids` (int64) stable per instance for undo/erase/edit workflows
+  - [ ] Optional `velocities`, `accelerations`, `angularVelocities` if needed
+- [ ] Array-length invariants
+  - [ ] `protoIndices`, `positions`, and any authored `orientations`/`scales` arrays are equal length for a given time sample
+  - [ ] All arrays are consistently time-sampled when animation is required; no mixed-sample shape mismatches
+- [ ] Transform/composition correctness
+  - [ ] Instancer xform prim defines parent space; per-instance transforms are applied relative to instancer
+  - [ ] World transform = instancer xform composed with per-instance position/orientation/scale
+  - [ ] Do not author 4x4 matrices per instance (use PI vectorized attributes as per OpenUSD guidance)
+- [ ] Prototype authoring
+  - [ ] Prototypes are referenced assets or subgraphs; ensure correctness when swapping assets (no reauthoring of per-instance arrays)
+  - [ ] Prefer prototype roots marked `instanceable` where beneficial; do not over-instance where it harms editability
+- [ ] Selection/identity
+  - [ ] Maintain stable `ids` to support deletion/selection of individual instances without reindexing arrays
+  - [ ] Use `invisibleIds` for soft delete when non-destructive erasing is required
+
+## Omniverse Interaction & UI Compliance
+- [ ] Brush interaction model
+  - [ ] Paint, Erase, and Flood modes consistent with Omniverse Paint Tool scatter
+  - [ ] Brush radius, density, stamp spacing, jitter/padding, vertical offset, surface normal alignment
+  - [ ] Randomization controls: seed, rotation (min/max or full random), non-uniform scale ranges
+  - [ ] Asset library selection and per-asset weighting
+  - [ ] Undo/Redo integrated using authoring command stack
+- [ ] Scene evaluation
+  - [ ] Surface raycast for placement; align orientation to hit normal (optional)
+  - [ ] Collision/padding checks to minimize interpenetration when padding > 0
+- [ ] Performance
+  - [ ] Batch edits (minimize array churn); author arrays via scoped command for stroke
+  - [ ] Recompute only changed segments; avoid per-sample re-authoring of entire arrays when erasing small subsets
+
+## RTX Remix Toolkit Integration Compliance
+- [ ] UI integration
+  - [ ] Add Scatter Brush panel/tool into Trex UI in a way consistent with Toolkit UI patterns (omni.ui + Trex style)
+- [ ] Viewport settings interplay
+  - [ ] Honor/benefit from Fabric Scene Delegate instancing settings (local docs — Merge Instances / Use Fabric Scene Graph Instancing)
+- [ ] Asset paths & project layout
+  - [ ] Prototypes reference assets within project or configured libraries; paths resolve in Toolkit and during packaging
+- [ ] Packaging/export for Runtime
+  - [ ] If RTX Remix Runtime supports PointInstancer directly — preserve PI in packaged USD
+  - [ ] If not supported — provide packaging option to Bake Instancer to explicit referenced prims/Xforms (compliance note below)
+
+## DXVK-Remix / RTX-Remix Runtime Considerations
+- [ ] Rendering parity
+  - [ ] Validate whether runtime supports PointInstancer; if unsupported, enable baking
+  - [ ] Ensure LOD/material bindings on prototypes are respected by instances in runtime
+- [ ] Performance
+  - [ ] Avoid pathological growth of instance count without LOD options
+- [ ] Determinism
+  - [ ] Author randomization with stored seed(s) for reproducible results across sessions
+
+## Data Integrity & Undo Compliance
+- [ ] Use a single undoable command scope per brush stroke
+- [ ] Assign unique `ids` on create; preserve `ids` on edits
+- [ ] For erase, prefer `invisibleIds` or sparse rebuild preserving order and ids where feasible
+
+## Security & Licensing
+- [ ] Ensure scattered assets comply with NVIDIA/Project licensing (see `artifacts/license_matrix.md`)
+
+## Explicit Local Documentation Citations
+- Viewport instancing toggles (Merge/Use Fabric Scene Graph Instancing)
+  - See `docs/toolkitinterface/remix-toolkitinterface-viewport.md` rows describing options 9 and 15 (Merge Instances / Use Fabric Scene Graph Instancing)
+- Authoring preference: Set "Instanceable" When Creating Reference
+  - See `docs/toolkitinterface/remix-toolkitinterface-viewport.md` authoring option 17
+- REST API tutorial patterns (command structure, authoring flows)
+  - See `docs/tutorials/tutorial-restapi.md`
+
+## Compliance Outcomes
+- [ ] Authoring produces valid OpenUSD PointInstancer per schema
+- [ ] Toolkit UI provides parity with Composer/Paint Tool scatter behaviors
+- [ ] Packaging path validated for runtime support (preserve or bake)
+- [ ] Performance guidelines met for interactive strokes and large instance counts
+
+## Identified Gaps / Actions for Web Research Agent
+- G1: Confirm RTX-Remix Runtime support status for `UsdGeomPointInstancer` and any constraints — fetch official statement from @RTX-RemixGithub docs/issues
+- G2: Identify official @Bridge-RemixGithub repository URL and any guidance for PI support during import/export
+- G3: Identify official @ComfyUI-RTX-RemixGithub repository URL and whether it exposes scatter automation
+- G4: Omniverse Paint Tool scatter exact parameter names and defaults — capture authoritative list with links/anchors from Omniverse docs
+- G5: Provide examples/best-practices from OpenUSD for large PI authoring (sparse updates, ids management)
+
+Once gaps are resolved, update this checklist with the definitive references and mark items as Verified.

--- a/REVERSE_ENGINEERING_NOTES.md
+++ b/REVERSE_ENGINEERING_NOTES.md
@@ -1,0 +1,95 @@
+# Reverse Engineering Notes — Scatter Brush (USD Composer → RTX Remix Toolkit)
+
+These notes capture the inferred behavior, UI, and data model of the USD Composer Scatter Brush (and Omniverse Paint Tool scatter) and translate them to an RTX Remix Toolkit implementation plan grounded in OpenUSD.
+
+## High-Level Behavior
+- The Scatter Brush uses OpenUSD `UsdGeomPointInstancer` (PI) as the backing data container.
+- The user selects one or more prototype assets; the brush paints instances onto target surfaces with configurable randomness and density.
+- Erase and Flood operations modify the same PI arrays, preserving per-instance identity (`ids`).
+
+## Data Model (OpenUSD)
+- `UsdGeomPointInstancer` attributes in scope:
+  - `prototypes` (relationship[] to root prims of prototype subgraphs)
+  - `protoIndices` (int[]), one entry per instance
+  - `positions` (vec3f[] or vec3d[])
+  - `orientations` (quath[]), optional; identity if absent
+  - `scales` (vec3f[]), optional; ones if absent
+  - `ids` (int64[]), optional; recommended for stable selection/undo/erase
+  - Optional kinematic attributes (`velocities`, etc.) typically unused for static scatter
+- Invariants
+  - Array lengths match across authored arrays per time sample
+  - Prototypes indexed by `protoIndices[i]` refer to `prototypes` order
+
+## UI States and Controls (Composer/Paint parity)
+- Mode: Paint | Erase | Flood
+- Brush radius
+- Density / stamp spacing
+- Padding (object-object spacing)
+- Vertical offset (along surface normal)
+- Align to surface normal (toggle)
+- Randomization:
+  - Seed
+  - Rotation randomization: min/max per-axis or around-normal twist
+  - Scale randomization: uniform or per-axis min/max
+  - Position jitter within brush stamp
+- Asset library panel:
+  - Asset selection (multi)
+  - Per-asset weight/probability sliders
+
+## Event Flow (Stroke)
+1. Pointer-down: begin stroke
+   - Capture seed state and target PI prim path
+   - Start undoable command scope
+2. Brush move: for each stamp along stroke path
+   - Raycast points on target surfaces within brush radius
+   - For each sample:
+     - Check padding/collision constraints
+     - Sample asset prototype using weights
+     - Compute position (hit point + offset), orientation (aligned to normal + random twist), scale (random range)
+     - Append to local buffers for `positions`, `orientations` (if authored), `scales` (if authored), `protoIndices`, `ids`
+3. Pointer-up: end stroke
+   - Batch-author array updates into PI attributes
+   - Close undo scope
+
+Erase mode:
+- Raycast/select instances within brush; either mark via `invisibleIds` or rebuild arrays without the erased ids while preserving others.
+
+Flood mode:
+- Compute region seeds based on selection/volume; generate consistent deterministic distribution with given density and seed; author arrays in single operation.
+
+## Authoring Strategy
+- Prefer batched writes: build arrays in memory per stroke; author once per stroke to minimize USD change processing.
+- Preserve stable `ids`; assign monotonic ids for new instances.
+- For erasing, avoid reindexing unrelated instances; either filter by `ids` or use visibility masks.
+
+## Performance Considerations
+- PI scales to very large instance counts; still, authoring cost can spike on full-array rewrites.
+- Strategies:
+  - Sparse updates when feasible (append-only for paint)
+  - Deferred rebuild for erase with minimal copy
+  - Avoid per-sample Sdf change notifications (wrap in command/overlay)
+
+## RTX Remix Toolkit Integration
+- UI: Implement with `omni.ui` following Trex style; add Scatter Brush tool/panel.
+- Viewport: Honor Merge Instances and Use Fabric Scene Graph Instancing settings (see local viewport docs).
+- Asset paths: Prototypes should be referenced assets within the Toolkit project layout for portability.
+- Packaging: If RTX Remix Runtime supports PI, keep instancers; otherwise implement a Bake to Xforms option for runtime packaging.
+
+## Edge Cases
+- Mixed prototype sets changing over time — maintain mapping and only append/remove references when needed
+- Unit scale consistency — respect stage metersPerUnit and prototype authored scale
+- Surface backface hits — optionally reject/backface-cull
+
+## References
+- OpenUSD UsdGeomPointInstancer: `https://openusd.org/docs/api/class_usd_geom_point_instancer.html`
+- Omniverse Build a Scatter Tool: `https://docs.omniverse.nvidia.com/workflows/latest/extensions/scatter_tool.html`
+- Omniverse Paint Tool: `https://docs.omniverse.nvidia.com/extensions/latest/ext_paint-tool.html`
+- Toolkit local docs: `docs/toolkitinterface/remix-toolkitinterface-viewport.md`, `docs/tutorials/tutorial-restapi.md`
+- RTX Remix Runtime repo: `https://github.com/NVIDIAGameWorks/rtx-remix`
+- DXVK-Remix repo: `https://github.com/NVIDIAGameWorks/dxvk-remix`
+
+## Open Questions for Web Research Agent
+- Q1: Confirm RTX Remix Runtime support/limitations for `UsdGeomPointInstancer` rendering and material bindings.
+- Q2: Official parameters list and defaults for Omniverse Paint Tool scatter brush (names, ranges).
+- Q3: Bridge pipeline handling of PI (import/export) and any constraints.
+- Q4: Recommended practices for PI `ids` management at scale from OpenUSD docs or NVIDIA guidance.

--- a/SCATTER_MAPPING.md
+++ b/SCATTER_MAPPING.md
@@ -1,0 +1,90 @@
+# USD Composer Scatter Brush → RTX Remix Toolkit Mapping
+
+This table maps USD Composer/Omniverse Scatter Brush features to RTX Remix Toolkit implementation, noting any differences and compliance references.
+
+## Legend
+- PI = UsdGeomPointInstancer
+- Ref links are provided at bottom
+
+## Feature Mapping
+
+- Feature: Point instancing backend
+  - USD Composer: UsdGeomPointInstancer
+  - RTX Remix Toolkit: UsdGeomPointInstancer (authoring in Trex)
+  - Notes: Ensure `prototypes`, `protoIndices`, `positions`, optional `orientations`, `scales`, and `ids` compliance
+  - Refs: OpenUSD PI, Omniverse Scatter Tool
+
+- Feature: Prototype asset selection (multi-asset, weights)
+  - USD Composer: Asset list with selection/weights via Paint/Scatter tool
+  - RTX Remix Toolkit: Trex asset browser + weights (to implement in Scatter UI)
+  - Notes: Store per-asset weight; translate to probability when generating `protoIndices`
+  - Refs: Paint Tool doc (asset painting)
+
+- Feature: Placement algorithm (surface-based)
+  - USD Composer: Raycast to surfaces, place instances aligned to hit
+  - RTX Remix Toolkit: Use Trex/Kit picking/raycast; compute position from brush stamp and surface normal
+  - Notes: Brush spacing/padding to reduce overlap
+  - Refs: Paint Tool
+
+- Feature: Brush modes (Paint, Erase, Flood)
+  - USD Composer: Provided by Paint Tool scatter
+  - RTX Remix Toolkit: Implement authoring commands for add/remove (erase) and flood (batch fill)
+  - Notes: Use `ids` and optionally `invisibleIds` for non-destructive erase
+  - Refs: Paint Tool
+
+- Feature: Randomization (seed, rotation, scale, jitter)
+  - USD Composer: Controls for random rot/scale and jitter
+  - RTX Remix Toolkit: UI sliders/fields for seed, rotation ranges, non-uniform scale ranges, translation jitter
+  - Notes: Persist seed for determinism; write arrays once per stroke
+  - Refs: Omniverse Scatter Tool
+
+- Feature: Density / Count controls
+  - USD Composer: Density and max count in region
+  - RTX Remix Toolkit: Density per area via brush radius & spacing; or absolute count for flood
+  - Notes: Deterministic sampling with seed
+  - Refs: Scatter Tool
+
+- Feature: Orientation alignment
+  - USD Composer: Align to surface normal optional
+  - RTX Remix Toolkit: Toggle; generate `orientations` from normal and a random around-normal twist
+  - Notes: Quaternion authoring per instance when enabled
+  - Refs: Paint Tool
+
+- Feature: Vertical offset / padding
+  - USD Composer: Controls available in Paint Tool
+  - RTX Remix Toolkit: Offset along normal; padding used in collision checks before authoring
+  - Notes: Avoid interpenetration
+  - Refs: Paint Tool
+
+- Feature: Undo/Redo integration
+  - USD Composer: Uses Omniverse/Kit undo
+  - RTX Remix Toolkit: Wrap stroke in a single undoable command; granular ids preserved
+  - Notes: Critical for parity and user trust
+  - Refs: Scatter Tool tutorial
+
+- Feature: Performance and batching
+  - USD Composer: Efficient updates to PI arrays
+  - RTX Remix Toolkit: Batch authoring; sparse edits; avoid full re-write per stroke
+  - Notes: Keep arrays contiguous; rebuild with minimal churn
+  - Refs: OpenUSD PI notes
+
+- Feature: Packaging for runtime
+  - USD Composer: Keep PI for Omniverse runtime
+  - RTX Remix Toolkit: Prefer keeping PI; add optional bake-to-xforms if Remix Runtime lacks PI support
+  - Notes: Compliance gate on runtime capability
+  - Refs: RTX Remix Runtime docs (TBD)
+
+## Divergences and Alternatives
+- If RTX Remix Runtime cannot render `UsdGeomPointInstancer`, provide a bake option that expands instances into referenced `Xform` prims (with transforms and material bindings inherited from prototypes), gated by a packaging toggle.
+- If Fabric Scene Delegate instancing options affect visibility or performance, document recommended settings for Scatter workflows.
+
+## References
+- OpenUSD UsdGeomPointInstancer: `https://openusd.org/docs/api/class_usd_geom_point_instancer.html`
+- Omniverse Build a Scatter Tool: `https://docs.omniverse.nvidia.com/workflows/latest/extensions/scatter_tool.html`
+- Omniverse Paint Tool: `https://docs.omniverse.nvidia.com/extensions/latest/ext_paint-tool.html`
+- RTX Remix Toolkit (this repo docs): see `docs/toolkitinterface/remix-toolkitinterface-viewport.md`
+- RTX Remix Runtime repo: `https://github.com/NVIDIAGameWorks/rtx-remix`
+- DXVK-Remix repo: `https://github.com/NVIDIAGameWorks/dxvk-remix`
+- Toolkit repo: `https://github.com/NVIDIAGameWorks/toolkit-remix`
+- Bridge repo: (TBD)
+- ComfyUI RTX Remix repo: (TBD)


### PR DESCRIPTION
Establishes initial documentation for the Scatter Brush feature.

Defines compliance standards, feature mapping, and reverse engineering notes for the RTX Remix Toolkit Scatter Brush, based on NVIDIA and OpenUSD specifications.

---
<a href="https://cursor.com/background-agent?bcId=bc-100ce41c-e3a6-4674-a47a-97533caee876">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-100ce41c-e3a6-4674-a47a-97533caee876">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

