### PR TITLE
Implement scatter brush UI and toolbar

### DIFF
--- a/source/extensions/lightspeed.trex.tools.scatter_brush/config/extension.toml
+++ b/source/extensions/lightspeed.trex.tools.scatter_brush/config/extension.toml
@@ -1,0 +1,42 @@
+[package]
+version = "0.1.0"
+authors =["Toolkit Agent <agent@example.com>"]
+title = "RTX Remix Scatter Brush (UI)"
+description = "Scatter Brush UI panel and hotkey integration for RTX Remix."
+readme = "docs/README.md"
+repository = "https://example.com/lightspeed.trex.tools.scatter_brush"
+category = "internal"
+keywords = ["remix", "scatter", "brush", "tools"]
+
+[dependencies]
+"omni.ui" = {}
+"carb" = {}
+"carb.settings" = {}
+"omni.kit.hotkeys.core" = {}
+"omni.flux.utils.common" = {}
+"omni.flux.utils.widget" = {}
+"lightspeed.trex.utils.widget" = {}
+"lightspeed.trex.hotkeys" = {}
+# Optional: leverage existing toolbar button if present
+"lightspeed.trex.viewports.shared.widget" = {}
+
+[[python.module]]
+name = "lightspeed.trex.tools.scatter_brush"
+
+[settings]
+# Persisted defaults for scatter brush UI
+exts."lightspeed.trex.tools.scatter_brush".enabled = false
+exts."lightspeed.trex.tools.scatter_brush".asset_usd_path = ""
+exts."lightspeed.trex.tools.scatter_brush".brush_radius = 0.25
+exts."lightspeed.trex.tools.scatter_brush".spacing = 0.5
+exts."lightspeed.trex.tools.scatter_brush".density = 8.0
+exts."lightspeed.trex.tools.scatter_brush".random_scale_min = 0.9
+exts."lightspeed.trex.tools.scatter_brush".random_scale_max = 1.1
+exts."lightspeed.trex.tools.scatter_brush".random_yaw = true
+exts."lightspeed.trex.tools.scatter_brush".align_to_normals = true
+exts."lightspeed.trex.tools.scatter_brush".max_surface_angle_deg = 45.0
+exts."lightspeed.trex.tools.scatter_brush".seed = 1337
+exts."lightspeed.trex.tools.scatter_brush".erase_mode = false
+exts."lightspeed.trex.tools.scatter_brush".category = ""
+# Optional index path for pre-ingested prototypes
+exts."lightspeed.trex.tools.scatter_brush".prototypes_index = ""

--- a/source/extensions/lightspeed.trex.tools.scatter_brush/docs/README.md
+++ b/source/extensions/lightspeed.trex.tools.scatter_brush/docs/README.md
@@ -1,0 +1,3 @@
+# Scatter Brush UI Extension
+
+Provides a left-panel UI for a Scatter Brush tool and a hotkey (B) to toggle brush mode. Settings persist in carb.settings under exts."lightspeed.trex.tools.scatter_brush".*.

--- a/source/extensions/lightspeed.trex.tools.scatter_brush/lightspeed/trex/tools/scatter_brush/__init__.py
+++ b/source/extensions/lightspeed.trex.tools.scatter_brush/lightspeed/trex/tools/scatter_brush/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+from .model import ScatterBrushSettings, ScatterBrushModel
+from .ui import ScatterBrushPane

--- a/source/extensions/lightspeed.trex.tools.scatter_brush/lightspeed/trex/tools/scatter_brush/extension.py
+++ b/source/extensions/lightspeed.trex.tools.scatter_brush/lightspeed/trex/tools/scatter_brush/extension.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import carb
+import carb.input
+import carb.settings
+import omni.ext
+from omni.kit.hotkeys.core import KeyCombination
+
+from lightspeed.trex.hotkeys.hotkey import AppHotkey
+from lightspeed.events_manager import get_instance as _get_event_manager_instance
+
+from .model import get_model
+from .ui import ScatterBrushPane
+
+
+_SETTINGS_CHANGED_EVENT = "lightspeed.trex.tools.scatter_brush.settings_changed"
+_TOGGLED_EVENT = "lightspeed.trex.tools.scatter_brush.toggled"
+
+
+class ScatterBrushExtension(omni.ext.IExt):
+    def __init__(self):
+        super().__init__()
+        self._ui: ScatterBrushPane | None = None
+        self._hotkey: AppHotkey | None = None
+        self._settings_sub: int | None = None
+        self._subs = []
+
+    def on_startup(self, ext_id):
+        carb.log_info("[lightspeed.trex.tools.scatter_brush] Startup")
+        self._ui = ScatterBrushPane()
+
+        # Register events
+        evt_mgr = _get_event_manager_instance()
+        evt_mgr.register_global_custom_event(_SETTINGS_CHANGED_EVENT)
+        evt_mgr.register_global_custom_event(_TOGGLED_EVENT)
+
+        # Bridge model events to global events
+        self._subs.append(get_model().subscribe_changed(lambda data: evt_mgr.call_global_custom_event(_SETTINGS_CHANGED_EVENT, data)))
+        self._subs.append(get_model().subscribe_toggle(lambda enabled: evt_mgr.call_global_custom_event(_TOGGLED_EVENT, enabled)))
+
+        # Register 'B' hotkey to toggle brush enabled state and try to toggle toolbar button if present
+        def _on_hotkey():
+            model = get_model()
+            try:
+                model.set_enabled(not model.enabled)
+            except Exception:
+                pass
+            # Best-effort toggle the existing shared scatter toolbar button if present
+            try:
+                from lightspeed.trex.viewports.shared.widget.tools import scatter_brush as _scatter_mod
+                btn = getattr(_scatter_mod, "_scatter_button_group", None)
+                if btn is not None and hasattr(btn, "_model"):
+                    current = bool(btn._model.get_value_as_bool())
+                    btn._model.set_value(not current)
+            except Exception:
+                # okay if toolbar not present or API changed
+                pass
+
+        self._hotkey = AppHotkey(
+            action_id="trex::Scatter Brush Toggle",
+            key=KeyCombination(carb.input.KeyboardInput.B),
+            action=_on_hotkey,
+            display_name="Scatter Brush Toggle (B)",
+            description="Toggle Scatter Brush mode",
+        )
+
+        # Listen to settings changes to reflect external toggles (e.g., toolbar) back into model
+        settings = carb.settings.get_settings()
+        path = 'exts."lightspeed.trex.tools.scatter_brush".enabled'
+        def _on_setting_changed(path_, value):
+            try:
+                if path_ == path:
+                    get_model().set_enabled(bool(value))
+            except Exception:
+                pass
+        self._settings_sub = settings.subscribe_to_node_change_events(_on_setting_changed)
+
+    def on_shutdown(self):
+        carb.log_info("[lightspeed.trex.tools.scatter_brush] Shutdown")
+        if self._hotkey:
+            self._hotkey.destroy()
+            self._hotkey = None
+        if self._ui:
+            self._ui.destroy()
+            self._ui = None
+        if self._settings_sub is not None:
+            try:
+                carb.settings.get_settings().unsubscribe_to_change_events(self._settings_sub)
+            except Exception:
+                pass
+            self._settings_sub = None
+        self._subs = []

--- a/source/extensions/lightspeed.trex.tools.scatter_brush/lightspeed/trex/tools/scatter_brush/model.py
+++ b/source/extensions/lightspeed.trex.tools.scatter_brush/lightspeed/trex/tools/scatter_brush/model.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import carb
+import carb.settings
+from omni.flux.utils.common import Event, EventSubscription
+
+_SETTINGS_ROOT = 'exts."lightspeed.trex.tools.scatter_brush"'
+
+
+@dataclass
+class ScatterBrushSettings:
+    asset_usd_path: str = ""
+    brush_radius: float = 0.25
+    spacing: float = 0.5
+    density: float = 8.0
+    random_scale_min: float = 0.9
+    random_scale_max: float = 1.1
+    random_yaw: bool = True
+    align_to_normals: bool = True
+    max_surface_angle_deg: float = 45.0
+    seed: int = 1337
+    erase_mode: bool = False
+    category: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class ScatterBrushModel:
+    """Typed settings model for Scatter Brush with persistence and events."""
+
+    def __init__(self):
+        self._settings = carb.settings.get_settings()
+        self._on_changed = Event()
+        self._on_toggle = Event()
+        self._enabled: bool = bool(self._settings.get(f"{_SETTINGS_ROOT}.enabled"))
+        self._data: ScatterBrushSettings = self._load()
+
+    # Persistence
+    def _load(self) -> ScatterBrushSettings:
+        gs = self._settings
+        return ScatterBrushSettings(
+            asset_usd_path=str(gs.get(f"{_SETTINGS_ROOT}.asset_usd_path") or ""),
+            brush_radius=float(gs.get(f"{_SETTINGS_ROOT}.brush_radius") or 0.25),
+            spacing=float(gs.get(f"{_SETTINGS_ROOT}.spacing") or 0.5),
+            density=float(gs.get(f"{_SETTINGS_ROOT}.density") or 8.0),
+            random_scale_min=float(gs.get(f"{_SETTINGS_ROOT}.random_scale_min") or 0.9),
+            random_scale_max=float(gs.get(f"{_SETTINGS_ROOT}.random_scale_max") or 1.1),
+            random_yaw=bool(gs.get(f"{_SETTINGS_ROOT}.random_yaw") or True),
+            align_to_normals=bool(gs.get(f"{_SETTINGS_ROOT}.align_to_normals") or True),
+            max_surface_angle_deg=float(gs.get(f"{_SETTINGS_ROOT}.max_surface_angle_deg") or 45.0),
+            seed=int(gs.get(f"{_SETTINGS_ROOT}.seed") or 1337),
+            erase_mode=bool(gs.get(f"{_SETTINGS_ROOT}.erase_mode") or False),
+            category=str(gs.get(f"{_SETTINGS_ROOT}.category") or ""),
+        )
+
+    def _save(self):
+        gs = self._settings
+        gs.set(f"{_SETTINGS_ROOT}.enabled", bool(self._enabled))
+        gs.set(f"{_SETTINGS_ROOT}.asset_usd_path", self._data.asset_usd_path)
+        gs.set(f"{_SETTINGS_ROOT}.brush_radius", float(self._data.brush_radius))
+        gs.set(f"{_SETTINGS_ROOT}.spacing", float(self._data.spacing))
+        gs.set(f"{_SETTINGS_ROOT}.density", float(self._data.density))
+        gs.set(f"{_SETTINGS_ROOT}.random_scale_min", float(self._data.random_scale_min))
+        gs.set(f"{_SETTINGS_ROOT}.random_scale_max", float(self._data.random_scale_max))
+        gs.set(f"{_SETTINGS_ROOT}.random_yaw", bool(self._data.random_yaw))
+        gs.set(f"{_SETTINGS_ROOT}.align_to_normals", bool(self._data.align_to_normals))
+        gs.set(f"{_SETTINGS_ROOT}.max_surface_angle_deg", float(self._data.max_surface_angle_deg))
+        gs.set(f"{_SETTINGS_ROOT}.seed", int(self._data.seed))
+        gs.set(f"{_SETTINGS_ROOT}.erase_mode", bool(self._data.erase_mode))
+        gs.set(f"{_SETTINGS_ROOT}.category", self._data.category)
+
+    # Accessors
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def data(self) -> ScatterBrushSettings:
+        return self._data
+
+    # Mutators trigger save + event
+    def set_enabled(self, value: bool):
+        value = bool(value)
+        if self._enabled != value:
+            self._enabled = value
+            self._save()
+            self._on_toggle(value)
+            self._on_changed(self._data)
+
+    def update(self, **kwargs):
+        changed = False
+        for k, v in kwargs.items():
+            if hasattr(self._data, k) and getattr(self._data, k) != v:
+                setattr(self._data, k, v)
+                changed = True
+        if changed:
+            self._save()
+            self._on_changed(self._data)
+
+    # Events
+    def subscribe_changed(self, fn: Callable[[ScatterBrushSettings], None]) -> EventSubscription:
+        return EventSubscription(self._on_changed, fn)
+
+    def subscribe_toggle(self, fn: Callable[[bool], None]) -> EventSubscription:
+        return EventSubscription(self._on_toggle, fn)
+
+    # Prototypes index helpers
+    def get_prototypes_index_path(self) -> Optional[Path]:
+        raw = self._settings.get(f"{_SETTINGS_ROOT}.prototypes_index")
+        if raw:
+            p = Path(str(raw))
+            if p.exists():
+                return p
+        # Best-effort defaults: try common locations if present
+        candidates: List[Path] = []
+        try:
+            import os
+            root = Path(os.getcwd())
+            candidates.append(root / "extensions/omniscatter/data/prototypes/prototypes_index.json")
+            candidates.append(root / "_build/release/extensions/omniscatter/data/prototypes/prototypes_index.json")
+            candidates.append(root / "_build/debug/extensions/omniscatter/data/prototypes/prototypes_index.json")
+        except Exception:
+            pass
+        for c in candidates:
+            if c.exists():
+                return c
+        return None
+
+    def load_prototypes(self) -> List[Dict[str, Any]]:
+        path = self.get_prototypes_index_path()
+        if not path:
+            return []
+        try:
+            import json
+            data = json.loads(path.read_text())
+            protos = data.get("prototypes") or []
+            # Normalize paths
+            out: List[Dict[str, Any]] = []
+            for p in protos:
+                item = dict(p)
+                # Keep absolute/relative path as-is; UI will resolve relative to index dir
+                out.append(item)
+            return out
+        except Exception as e:
+            carb.log_warn(f"Failed to load prototypes index: {e}")
+            return []
+
+# Global/shared instance access
+_global_model: ScatterBrushModel | None = None
+
+def get_model() -> ScatterBrushModel:
+    global _global_model
+    if _global_model is None:
+        _global_model = ScatterBrushModel()
+    return _global_model

--- a/source/extensions/lightspeed.trex.tools.scatter_brush/lightspeed/trex/tools/scatter_brush/ui.py
+++ b/source/extensions/lightspeed.trex.tools.scatter_brush/lightspeed/trex/tools/scatter_brush/ui.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import carb
+import omni.ui as ui
+
+from lightspeed.common import constants as _constants
+from omni.flux.utils.widget.collapsable_frame import PropertyCollapsableFrameWithInfoPopup
+
+from .model import get_model
+
+
+class ScatterBrushPane:
+    """Docked left panel containing Scatter Brush settings and an asset picker."""
+
+    TITLE = "SCATTER BRUSH"
+
+    def __init__(self):
+        self._model = get_model()
+        self._window: Optional[ui.Window] = None
+        self._asset_container: Optional[ui.Widget] = None
+        self._build_ui()
+
+    def _build_ui(self):
+        self._window = ui.Window(
+            "Scatter Brush",
+            width=340,
+            height=600,
+            dockPreference=ui.DockPreference.LEFT,
+            flags=(ui.WINDOW_FLAGS_NO_SCROLLBAR | ui.WINDOW_FLAGS_NO_COLLAPSE),
+        )
+        with self._window.frame:
+            with ui.ZStack():
+                ui.Rectangle(name="WorkspaceBackground")
+                with ui.ScrollingFrame(name="PropertiesPaneSection", horizontal_scrollbar_policy=ui.ScrollBarPolicy.SCROLLBAR_ALWAYS_OFF):
+                    with ui.VStack(spacing=ui.Pixel(8)):
+                        ui.Spacer(height=ui.Pixel(8))
+                        with ui.HStack():
+                            ui.Spacer(width=ui.Pixel(8))
+                            with ui.VStack(spacing=ui.Pixel(8)):
+                                # Collapsible group header
+                                coll = PropertyCollapsableFrameWithInfoPopup(
+                                    self.TITLE,
+                                    info_text=(
+                                        "Paint-scatter pre-ingested assets onto surfaces.\n\n"
+                                        "- Use the toolbar toggle or 'B' to activate brush mode.\n"
+                                        "- Settings persist across sessions.\n"
+                                    ),
+                                    collapsed=False,
+                                )
+                                with coll:
+                                    self._build_content()
+
+    def _build_content(self):
+        # Asset picker
+        with ui.VStack(spacing=ui.Pixel(6)):
+            ui.Label("Asset", name="PropertiesWidgetLabel")
+            self._asset_container = ui.VStack()
+            with self._asset_container:
+                self._rebuild_assets()
+
+        ui.Spacer(height=ui.Pixel(8))
+        ui.Line(name="PropertiesPaneSectionTitle")
+
+        # Brush settings
+        with ui.VGrid(column_count=2, row_spacing=ui.Pixel(6), column_spacing=ui.Pixel(8)):
+            ui.Label("Radius", name="PropertiesWidgetLabel")
+            r = ui.FloatDrag(min=0.01, max=1000.0, step=0.01, style_type_name_override="Field")
+            r.model.set_value(self._model.data.brush_radius)
+            r.model.add_value_changed_fn(lambda m: self._on_change(brush_radius=float(m.get_value_as_float())))
+
+            ui.Label("Spacing", name="PropertiesWidgetLabel")
+            sp = ui.FloatDrag(min=0.0, max=1000.0, step=0.01, style_type_name_override="Field")
+            sp.model.set_value(self._model.data.spacing)
+            sp.model.add_value_changed_fn(lambda m: self._on_change(spacing=float(m.get_value_as_float())))
+
+            ui.Label("Density (pts/m²)", name="PropertiesWidgetLabel")
+            den = ui.FloatDrag(min=0.0, max=10000.0, step=0.1, style_type_name_override="Field")
+            den.model.set_value(self._model.data.density)
+            den.model.add_value_changed_fn(lambda m: self._on_change(density=float(m.get_value_as_float())))
+
+            ui.Label("Random Scale Min", name="PropertiesWidgetLabel")
+            smin = ui.FloatDrag(min=0.01, max=100.0, step=0.01, style_type_name_override="Field")
+            smin.model.set_value(self._model.data.random_scale_min)
+            smin.model.add_value_changed_fn(lambda m: self._on_change(random_scale_min=float(m.get_value_as_float())))
+
+            ui.Label("Random Scale Max", name="PropertiesWidgetLabel")
+            smax = ui.FloatDrag(min=0.01, max=100.0, step=0.01, style_type_name_override="Field")
+            smax.model.set_value(self._model.data.random_scale_max)
+            smax.model.add_value_changed_fn(lambda m: self._on_change(random_scale_max=float(m.get_value_as_float())))
+
+            ui.Label("Random Yaw", name="PropertiesWidgetLabel")
+            ry = ui.CheckBox()
+            ry.model.set_value(self._model.data.random_yaw)
+            ry.model.add_value_changed_fn(lambda m: self._on_change(random_yaw=bool(m.get_value_as_bool())))
+
+            ui.Label("Align to Normals", name="PropertiesWidgetLabel")
+            aln = ui.CheckBox()
+            aln.model.set_value(self._model.data.align_to_normals)
+            aln.model.add_value_changed_fn(lambda m: self._on_change(align_to_normals=bool(m.get_value_as_bool())))
+
+            ui.Label("Surface Angle Limit", name="PropertiesWidgetLabel")
+            ang = ui.FloatDrag(min=0.0, max=90.0, step=0.5, style_type_name_override="Field")
+            ang.model.set_value(self._model.data.max_surface_angle_deg)
+            ang.model.add_value_changed_fn(
+                lambda m: self._on_change(max_surface_angle_deg=float(m.get_value_as_float()))
+            )
+
+            ui.Label("Seed", name="PropertiesWidgetLabel")
+            sd = ui.IntDrag(min=0, max=2**31 - 1, step=1, style_type_name_override="Field")
+            sd.model.set_value(self._model.data.seed)
+            sd.model.add_value_changed_fn(lambda m: self._on_change(seed=int(m.get_value_as_int())))
+
+            ui.Label("Erase Mode", name="PropertiesWidgetLabel")
+            er = ui.CheckBox()
+            er.model.set_value(self._model.data.erase_mode)
+            er.model.add_value_changed_fn(lambda m: self._on_change(erase_mode=bool(m.get_value_as_bool())))
+
+        ui.Spacer(height=ui.Pixel(8))
+        ui.Line(name="PropertiesPaneSectionTitle")
+
+        # Category dropdown
+        with ui.HStack(spacing=ui.Pixel(8)):
+            ui.Label("Category", name="PropertiesWidgetLabel", width=ui.Percent(40))
+            names = list(_constants.REMIX_CATEGORIES.keys())
+            initial_index = max(0, names.index(self._model.data.category) if self._model.data.category in names else 0)
+            combo_model = ui.SimpleIntModel(initial_index)
+            def _on_combo_changed(m):
+                idx = int(m.get_value_as_int())
+                value = names[idx] if 0 <= idx < len(names) else ""
+                self._on_change(category=value)
+            combo = ui.ComboBox(combo_model, *names)
+            combo_model.add_value_changed_fn(_on_combo_changed)
+
+    def _rebuild_assets(self):
+        def _resolve_thumb(index_dir: Path, record: Dict[str, Any]) -> Optional[str]:
+            thumb = record.get("thumbnail_128") or record.get("thumbnail")
+            if not thumb:
+                return None
+            p = Path(thumb)
+            if not p.is_absolute():
+                p = index_dir / p
+            return str(p)
+
+        protos = self._model.load_prototypes()
+        index_path = self._model.get_prototypes_index_path()
+        index_dir = index_path.parent if index_path else None
+
+        self._asset_container.clear()
+        with self._asset_container:
+            if not protos:
+                ui.Label("No pre-ingested assets found.")
+                return
+            with ui.VStack(spacing=ui.Pixel(6)):
+                for rec in protos:
+                    name = str(rec.get("name") or rec.get("uuid") or "asset")
+                    usd_path = rec.get("usd_path") or rec.get("usd") or ""
+                    if not usd_path:
+                        continue
+                    with ui.HStack(height=ui.Pixel(56)):
+                        # Thumbnail
+                        thumb_url = _resolve_thumb(index_dir, rec) if index_dir else None
+                        if thumb_url and Path(thumb_url).exists():
+                            ui.Image(thumb_url, width=ui.Pixel(56), height=ui.Pixel(56))
+                        else:
+                            ui.Rectangle(width=ui.Pixel(56), height=ui.Pixel(56))
+                        with ui.VStack():
+                            ui.Label(name)
+                            ui.Label(str(usd_path), name="PropertiesWidgetLabel")
+                        # Select button
+                        def _on_pick(this_usd=usd_path):
+                            # Persist relative to index dir as provided in index json
+                            self._on_change(asset_usd_path=str(this_usd))
+                        ui.Button("Select", clicked_fn=_on_pick)
+
+    def _on_change(self, **kwargs):
+        self._model.update(**kwargs)
+
+    def destroy(self):
+        if self._window:
+            self._window.visible = False
+            self._window = None

--- a/source/extensions/lightspeed.trex.viewports.shared.widget/lightspeed/trex/viewports/shared/widget/tools/scatter_brush.py
+++ b/source/extensions/lightspeed.trex.viewports.shared.widget/lightspeed/trex/viewports/shared/widget/tools/scatter_brush.py
@@ -86,6 +86,15 @@ class ScatterBrushButtonGroup(WidgetGroup):
 
         # subscribe to model changes to propagate
         self._model.add_value_changed_fn(lambda *_: self._notify(self._model.get_value_as_bool()))
+        # bridge to settings for external observers
+        def _settings_bridge():
+            try:
+                carb.settings.get_settings().set(
+                    'exts."lightspeed.trex.tools.scatter_brush".enabled', bool(self._model.get_value_as_bool())
+                )
+            except Exception:
+                pass
+        self._model.add_value_changed_fn(lambda *_: _settings_bridge())
 
     def _notify(self, value: bool):
         for cb in list(self.__on_toggled):


### PR DESCRIPTION
Implements the Scatter Brush UI extension with a left-panel, toolbar toggle, hotkey (B), and settings persistence.

---
<a href="https://cursor.com/background-agent?bcId=bc-d559bca7-a076-4780-bf89-9819eb1a1de6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d559bca7-a076-4780-bf89-9819eb1a1de6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

