### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels: [dependencies, automerge]
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ["*"]
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels: [dependencies, automerge]
+    open-pull-requests-limit: 5
+    groups:
+      python:
+        patterns: ["*"]


### PR DESCRIPTION
Adds `.github/dependabot.yml` to enable weekly grouped updates for GitHub Actions and pip (root `pyproject.toml`). Note: repo already had `.dependabot.toml` (legacy/different tool); this adds GitHub's native Dependabot. Part of the GitHub Pro rollout across all repos.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLffzPKQFUrbWcHsV5PhuU)_